### PR TITLE
allow non standard manuscript ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 credentials.json
-data_pipeline.egg-info
+*.egg-info
 .pytest_cache
 venv

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ dev-lint: dev-flake8 dev-pylint
 dev-unittest:
 	$(PYTHON) -m pytest -p no:cacheprovider $(ARGS) tests/unit_test
 
+dev-watch:
+	$(PYTHON) -m pytest_watch -- -p no:cacheprovider $(ARGS) tests/unit_test
+
 dev-dagtest:
 	$(PYTHON) -m pytest -p no:cacheprovider $(ARGS) tests/dag_validation_test
 

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,10 @@ dev-install:
 dev-venv: venv-create dev-install
 
 dev-flake8:
-	$(PYTHON) -m flake8 data_pipeline dags tests
+	$(PYTHON) -m flake8 ejp_xml_pipeline dags tests
 
 dev-pylint:
-	$(PYTHON) -m pylint data_pipeline dags tests
+	$(PYTHON) -m pylint ejp_xml_pipeline dags tests
 
 dev-lint: dev-flake8 dev-pylint
 

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -52,7 +52,7 @@ class ParsedManuscriptDocument(ParsedDocument):
         return self.persons + [self.manuscript] + self.versions
 
 
-MANUSCRIPT_NO_REGEX = re.compile(r'^.*-(\d{3,})\D?.*$')
+MANUSCRIPT_NO_REGEX = re.compile(r'^.*\D-(\d{3,})\D?.*$')
 
 
 def to_bool(bool_str):
@@ -67,13 +67,20 @@ def to_int(int_str):
     return int(int_str) if int_str else None
 
 
-def manuscript_number_to_manuscript_id(manuscript_number):
+def manuscript_number_to_manuscript_id(manuscript_number: str) -> str:
     LOGGER.debug('manuscript_number: %s', manuscript_number)
+    if not manuscript_number.strip():
+        raise ValueError('manuscript number must not be empty')
     match = MANUSCRIPT_NO_REGEX.match(manuscript_number)
     if not match:
-        raise ValueError(
-            'unrecognised manuscript-number format: %s' % manuscript_number
+        LOGGER.warning(
+            ' '.join([
+                'unrecognised manuscript-number format: %s'
+                '(falling back to full manuscript number)'
+            ]),
+            manuscript_number
         )
+        return manuscript_number
     return match.group(1)
 
 

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,3 +1,4 @@
 flake8==3.7.9
 pylint==2.5.0
 pytest==5.4.1
+pytest-watch==4.2.0

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -5,12 +5,15 @@ from typing import List
 from lxml.builder import E
 from lxml.etree import Element
 
+import pytest
+
 from ejp_xml_pipeline.utils.xml_transform_util.timestamp import (
     parse_timestamp, to_default_tz_display_format
 )
 
 from ejp_xml_pipeline.utils.xml_transform_util.extract import MemberTypes
 from ejp_xml_pipeline.transform_zip_xml.ejp_manuscript_xml import (
+    manuscript_number_to_manuscript_id,
     derive_version_id_from_manuscript_id_and_created_timestamp,
     parse_xml,
     OverallStageNames,
@@ -174,6 +177,25 @@ def _manuscript_xml(
 
 def _versions_prop(versions, key):
     return [v.data[key] for v in versions]
+
+
+class TestManuscriptNumberToManuscriptId:
+    def test_should_reject_empty_manuscript_number(self):
+        with pytest.raises(ValueError):
+            manuscript_number_to_manuscript_id('')
+
+    def test_should_reject_blank_manuscript_number(self):
+        with pytest.raises(ValueError):
+            manuscript_number_to_manuscript_id(' ')
+
+    def test_should_extract_elife_manuscript_id(self):
+        assert manuscript_number_to_manuscript_id('2020-01-02-RA-eLife-12345') == '12345'
+
+    def test_should_use_full_manuscript_number_if_not_elife_format(self):
+        assert manuscript_number_to_manuscript_id('123-12') == '123-12'
+
+    def test_should_use_full_manuscript_number_if_not_elife_format_but_long_digits(self):
+        assert manuscript_number_to_manuscript_id('123-12345') == '123-12345'
 
 
 class TestDeriveVersionIdFromManuscriptIdAndCreatedTimestamp:


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/5647

(will hopefully resolve it, but will need to test it with the actual zip file)

This should also resolve issues that didn't previously fail in the same way. i.e.

`415-10` failed because `10` is only two digits.
Whereas `415-100` would have passed and resulted in `100` as the manuscript id.
We probably don't care about the early `415` manuscript numbers, but may conflict or confuse the current manuscript ids.