### PR TITLE
suggested editors and reviewers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length = 90
+max-line-length = 100

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -514,6 +514,10 @@ def version_node_to_dict(
             version_node, 'potential-reviewing-editors/potential-reviewing-editor',
             partial(potential_person_node_to_dict, element_prefix='potential-reviewing-editor-')
         ),
+        'potential_senior_editors': extract_list(
+            version_node, 'potential-senior-editors/potential-senior-editor',
+            partial(potential_person_node_to_dict, element_prefix='potential-senior-editor-')
+        ),
         'author_funding': extract_list(
             version_node, 'author-funding/author-funding',
             author_funding_node_to_dict

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -333,10 +333,12 @@ def senior_editor_node_to_dict(senior_editor_node: Element) -> dict:
     }
 
 
-def _parse_yes_no(yes_no):
-    if yes_no == 'yes':
+def _parse_yes_no(yes_no: str) -> bool:
+    if not yes_no:
+        return None
+    if yes_no.lower() == 'yes':
         return True
-    if yes_no == 'no':
+    if yes_no.lower() == 'no':
         return False
     return None
 

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -264,30 +264,34 @@ def author_node_to_dict(author_node: Element) -> dict:
     }
 
 
-def reviewer_node_to_dict(reviewer_node: Element) -> dict:
+def reviewer_node_to_dict(
+        reviewer_node: Element,
+        element_prefix: str) -> dict:
     return {
         'person_id': get_and_decode_xml_child_text(
-            reviewer_node, 'referee-person-id'
+            reviewer_node, element_prefix + 'person-id'
         ),
         'sequence': to_int(get_and_decode_xml_child_text(
-            reviewer_node, 'referee-sequence'
+            reviewer_node, element_prefix + 'sequence'
         )),
         'started_timestamp': format_optional_to_iso_timestamp(
             get_and_decode_xml_child_text(
-                reviewer_node, 'referee-started-date'
+                reviewer_node, element_prefix + 'started-date'
             )
         ),
         'due_timestamp': format_optional_to_iso_timestamp(
-            get_and_decode_xml_child_text(reviewer_node, 'referee-due-date')
+            get_and_decode_xml_child_text(
+                reviewer_node, element_prefix + 'due-date'
+            )
         ),
         'next_chase_timestamp': format_optional_to_iso_timestamp(
             get_and_decode_xml_child_text(
-                reviewer_node, 'referee-next-chase-date'
+                reviewer_node, element_prefix + 'next-chase-date'
             )
         ),
         'received_timestamp': format_optional_to_iso_timestamp(
             get_and_decode_xml_child_text(
-                reviewer_node, 'referee-received-date'
+                reviewer_node, element_prefix + 'received-date'
             )
         )
     }
@@ -480,7 +484,11 @@ def version_node_to_dict(
             version_node, 'authors/author', author_node_to_dict
         ),
         'reviewers': extract_list(
-            version_node, 'referees/referee', reviewer_node_to_dict
+            version_node, 'referees/referee',
+            partial(reviewer_node_to_dict, element_prefix='referee-')
+        ) + extract_list(
+            version_node, 'reviewers/reviewer',
+            partial(reviewer_node_to_dict, element_prefix='reviewer-')
         ),
         'reviewing_editors': extract_list(
             version_node, 'editors/editor',

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -341,18 +341,18 @@ def _parse_yes_no(yes_no):
     return None
 
 
-def potential_reviewer_node_to_dict(
-        potential_reviewer_node: Element,
+def potential_person_node_to_dict(
+        potential_person_node: Element,
         element_prefix: str) -> dict:
     return {
         'person_id': get_and_decode_xml_child_text(
-            potential_reviewer_node, element_prefix + 'person-id'
+            potential_person_node, element_prefix + 'person-id'
         ),
         'suggested_to_include': _parse_yes_no(get_and_decode_xml_child_text(
-            potential_reviewer_node, element_prefix + 'suggested-to-include'
+            potential_person_node, element_prefix + 'suggested-to-include'
         )),
         'suggested_to_exclude': _parse_yes_no(get_and_decode_xml_child_text(
-            potential_reviewer_node, element_prefix + 'suggested-to-exclude'
+            potential_person_node, element_prefix + 'suggested-to-exclude'
         ))
     }
 
@@ -505,10 +505,14 @@ def version_node_to_dict(
         ),
         'potential_reviewers': extract_list(
             version_node, 'potential-referees/potential-referee',
-            partial(potential_reviewer_node_to_dict, element_prefix='potential-referee-')
+            partial(potential_person_node_to_dict, element_prefix='potential-referee-')
         ) + extract_list(
             version_node, 'potential-reviewers/potential-reviewer',
-            partial(potential_reviewer_node_to_dict, element_prefix='potential-reviewer-')
+            partial(potential_person_node_to_dict, element_prefix='potential-reviewer-')
+        ),
+        'potential_reviewing_editors': extract_list(
+            version_node, 'potential-reviewing-editors/potential-reviewing-editor',
+            partial(potential_person_node_to_dict, element_prefix='potential-reviewing-editor-')
         ),
         'author_funding': extract_list(
             version_node, 'author-funding/author-funding',

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -341,16 +341,18 @@ def _parse_yes_no(yes_no):
     return None
 
 
-def potential_reviewer_node_to_dict(potential_reviewer_node: Element) -> dict:
+def potential_reviewer_node_to_dict(
+        potential_reviewer_node: Element,
+        element_prefix: str) -> dict:
     return {
         'person_id': get_and_decode_xml_child_text(
-            potential_reviewer_node, 'potential-referee-person-id'
+            potential_reviewer_node, element_prefix + 'person-id'
         ),
         'suggested_to_include': _parse_yes_no(get_and_decode_xml_child_text(
-            potential_reviewer_node, 'potential-referee-suggested-to-include'
+            potential_reviewer_node, element_prefix + 'suggested-to-include'
         )),
         'suggested_to_exclude': _parse_yes_no(get_and_decode_xml_child_text(
-            potential_reviewer_node, 'potential-referee-suggested-to-exclude'
+            potential_reviewer_node, element_prefix + 'suggested-to-exclude'
         ))
     }
 
@@ -503,7 +505,10 @@ def version_node_to_dict(
         ),
         'potential_reviewers': extract_list(
             version_node, 'potential-referees/potential-referee',
-            potential_reviewer_node_to_dict
+            partial(potential_reviewer_node_to_dict, element_prefix='potential-referee-')
+        ) + extract_list(
+            version_node, 'potential-reviewers/potential-reviewer',
+            partial(potential_reviewer_node_to_dict, element_prefix='potential-reviewer-')
         ),
         'author_funding': extract_list(
             version_node, 'author-funding/author-funding',

--- a/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
+++ b/ejp_xml_pipeline/transform_zip_xml/ejp_manuscript_xml.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from datetime import datetime
+from functools import partial
 import re
 from typing import Tuple
 
@@ -292,19 +293,24 @@ def reviewer_node_to_dict(reviewer_node: Element) -> dict:
     }
 
 
-def reviewing_editor_node_to_dict(reviewing_editor_node: Element) -> dict:
+def reviewing_editor_node_to_dict(
+        reviewing_editor_node: Element,
+        element_prefix: str) -> dict:
     return {
         'person_id': get_and_decode_xml_child_text(
-            reviewing_editor_node, 'editor-person-id'
+            reviewing_editor_node,
+            element_prefix + 'person-id'
         ),
         'assigned_timestamp': format_optional_to_iso_timestamp(
             get_and_decode_xml_child_text(
-                reviewing_editor_node, 'editor-assigned-date'
+                reviewing_editor_node,
+                element_prefix + 'assigned-date'
             )
         ),
         'due_timestamp': format_optional_to_iso_timestamp(
             get_and_decode_xml_child_text(
-                reviewing_editor_node, 'editor-decision-due-date'
+                reviewing_editor_node,
+                element_prefix + 'decision-due-date'
             )
         )
     }
@@ -477,7 +483,11 @@ def version_node_to_dict(
             version_node, 'referees/referee', reviewer_node_to_dict
         ),
         'reviewing_editors': extract_list(
-            version_node, 'editors/editor', reviewing_editor_node_to_dict
+            version_node, 'editors/editor',
+            partial(reviewing_editor_node_to_dict, element_prefix='editor-')
+        ) + extract_list(
+            version_node, 'reviewing-editors/reviewing-editor',
+            partial(reviewing_editor_node_to_dict, element_prefix='reviewing-editor-')
         ),
         'senior_editors': extract_list(
             version_node, 'senior-editors/senior-editor',

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -649,7 +649,7 @@ class TestParseXml:
                 'assigned_timestamp': TIMESTAMP_1
             }]]
 
-        def test_should_extract_single_potential_reviewer(self):
+        def test_should_extract_single_potential_reviewer_from_potential_referees_element(self):
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({
                     **VERSION_1,
@@ -657,6 +657,23 @@ class TestParseXml:
                         'potential-referee-person-id': PERSON_ID_1,
                         'potential-referee-suggested-to-exclude': 'yes',
                         'potential-referee-suggested-to-include': 'no'
+                    }]
+                })])
+            )
+            assert _versions_prop(result.versions, 'potential_reviewers') == [[{
+                'person_id': PERSON_ID_1,
+                'suggested_to_exclude': True,
+                'suggested_to_include': False
+            }]]
+
+        def test_should_extract_single_potential_reviewer_from_potential_reviewers_element(self):
+            result = _parse_xml_with_defaults(
+                _manuscript_xml([_version_node({
+                    **VERSION_1,
+                    'potential-reviewers/potential-reviewer': [{
+                        'potential-reviewer-person-id': PERSON_ID_1,
+                        'potential-reviewer-suggested-to-exclude': 'yes',
+                        'potential-reviewer-suggested-to-include': 'no'
                     }]
                 })])
             )

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -687,10 +687,10 @@ class TestParseXml:
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({
                     **VERSION_1,
-                    'potential-referees/potential-referee': [{
-                        'potential-referee-person-id': PERSON_ID_1,
-                        'potential-referee-suggested-to-exclude': 'other',
-                        'potential-referee-suggested-to-include': 'other'
+                    'potential-reviewers/potential-reviewer': [{
+                        'potential-reviewer-person-id': PERSON_ID_1,
+                        'potential-reviewer-suggested-to-exclude': 'other',
+                        'potential-reviewer-suggested-to-include': 'other'
                     }]
                 })])
             )

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -700,6 +700,23 @@ class TestParseXml:
                 'suggested_to_include': None
             }]]
 
+        def test_should_extract_single_potential_reviewing_editor(self):
+            result = _parse_xml_with_defaults(
+                _manuscript_xml([_version_node({
+                    **VERSION_1,
+                    'potential-reviewing-editors/potential-reviewing-editor': [{
+                        'potential-reviewing-editor-person-id': PERSON_ID_1,
+                        'potential-reviewing-editor-suggested-to-exclude': 'yes',
+                        'potential-reviewing-editor-suggested-to-include': 'no'
+                    }]
+                })])
+            )
+            assert _versions_prop(result.versions, 'potential_reviewing_editors') == [[{
+                'person_id': PERSON_ID_1,
+                'suggested_to_exclude': True,
+                'suggested_to_include': False
+            }]]
+
         def test_should_extract_author_funding(self):
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -717,6 +717,23 @@ class TestParseXml:
                 'suggested_to_include': False
             }]]
 
+        def test_should_extract_single_potential_senior_editor(self):
+            result = _parse_xml_with_defaults(
+                _manuscript_xml([_version_node({
+                    **VERSION_1,
+                    'potential-senior-editors/potential-senior-editor': [{
+                        'potential-senior-editor-person-id': PERSON_ID_1,
+                        'potential-senior-editor-suggested-to-exclude': 'yes',
+                        'potential-senior-editor-suggested-to-include': 'no'
+                    }]
+                })])
+            )
+            assert _versions_prop(result.versions, 'potential_senior_editors') == [[{
+                'person_id': PERSON_ID_1,
+                'suggested_to_exclude': True,
+                'suggested_to_include': False
+            }]]
+
         def test_should_extract_author_funding(self):
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -672,8 +672,8 @@ class TestParseXml:
                     **VERSION_1,
                     'potential-reviewers/potential-reviewer': [{
                         'potential-reviewer-person-id': PERSON_ID_1,
-                        'potential-reviewer-suggested-to-exclude': 'yes',
-                        'potential-reviewer-suggested-to-include': 'no'
+                        'potential-reviewer-suggested-to-exclude': 'Yes',
+                        'potential-reviewer-suggested-to-include': 'No'
                     }]
                 })])
             )
@@ -700,14 +700,29 @@ class TestParseXml:
                 'suggested_to_include': None
             }]]
 
+        def test_should_return_none_if_include_exclude_are_not_present(self):
+            result = _parse_xml_with_defaults(
+                _manuscript_xml([_version_node({
+                    **VERSION_1,
+                    'potential-reviewers/potential-reviewer': [{
+                        'potential-reviewer-person-id': PERSON_ID_1
+                    }]
+                })])
+            )
+            assert _versions_prop(result.versions, 'potential_reviewers') == [[{
+                'person_id': PERSON_ID_1,
+                'suggested_to_exclude': None,
+                'suggested_to_include': None
+            }]]
+
         def test_should_extract_single_potential_reviewing_editor(self):
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({
                     **VERSION_1,
                     'potential-reviewing-editors/potential-reviewing-editor': [{
                         'potential-reviewing-editor-person-id': PERSON_ID_1,
-                        'potential-reviewing-editor-suggested-to-exclude': 'yes',
-                        'potential-reviewing-editor-suggested-to-include': 'no'
+                        'potential-reviewing-editor-suggested-to-exclude': 'Yes',
+                        'potential-reviewing-editor-suggested-to-include': 'No'
                     }]
                 })])
             )
@@ -723,8 +738,8 @@ class TestParseXml:
                     **VERSION_1,
                     'potential-senior-editors/potential-senior-editor': [{
                         'potential-senior-editor-person-id': PERSON_ID_1,
-                        'potential-senior-editor-suggested-to-exclude': 'yes',
-                        'potential-senior-editor-suggested-to-include': 'no'
+                        'potential-senior-editor-suggested-to-exclude': 'Yes',
+                        'potential-senior-editor-suggested-to-include': 'No'
                     }]
                 })])
             )

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -111,7 +111,6 @@ VERSION_1 = {
 LIST_AND_ITEM_TAG_NAME_BY_PROP = {
     'stages': ('history', 'stage'),
     'authors': ('authors', 'author'),
-    'reviewers': ('referees', 'referee'),
     'senior-editors': ('senior-editors', 'senior-editor'),
     'author-funding': ('author-funding', 'author-funding'),
     'themes': ('themes', 'theme'),
@@ -554,17 +553,40 @@ class TestParseXml:
                 'is_corresponding_author': True
             }]]
 
-        def test_should_extract_single_reviewer(self):
+        def test_should_extract_single_reviewer_from_referees_element(self):
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({
                     **VERSION_1,
-                    'reviewers': [{
+                    'referees/referee': [{
                         'referee-person-id': PERSON_ID_1,
                         'referee-sequence': '1',
                         'referee-started-date': NON_ISO_TIMESTAMP_1,
                         'referee-due-date': NON_ISO_TIMESTAMP_1,
                         'referee-next-chase-date': NON_ISO_TIMESTAMP_1,
                         'referee-received-date': NON_ISO_TIMESTAMP_1
+                    }]
+                })])
+            )
+            assert _versions_prop(result.versions, 'reviewers') == [[{
+                'person_id': PERSON_ID_1,
+                'sequence': 1,
+                'started_timestamp': TIMESTAMP_1,
+                'due_timestamp': TIMESTAMP_1,
+                'next_chase_timestamp': TIMESTAMP_1,
+                'received_timestamp': TIMESTAMP_1
+            }]]
+
+        def test_should_extract_single_reviewer_from_reviewers_element(self):
+            result = _parse_xml_with_defaults(
+                _manuscript_xml([_version_node({
+                    **VERSION_1,
+                    'reviewers/reviewer': [{
+                        'reviewer-person-id': PERSON_ID_1,
+                        'reviewer-sequence': '1',
+                        'reviewer-started-date': NON_ISO_TIMESTAMP_1,
+                        'reviewer-due-date': NON_ISO_TIMESTAMP_1,
+                        'reviewer-next-chase-date': NON_ISO_TIMESTAMP_1,
+                        'reviewer-received-date': NON_ISO_TIMESTAMP_1
                     }]
                 })])
             )

--- a/tests/unit_test/formats/ejp_manuscript_xml_test.py
+++ b/tests/unit_test/formats/ejp_manuscript_xml_test.py
@@ -112,7 +112,6 @@ LIST_AND_ITEM_TAG_NAME_BY_PROP = {
     'stages': ('history', 'stage'),
     'authors': ('authors', 'author'),
     'reviewers': ('referees', 'referee'),
-    'reviewing-editors': ('editors', 'editor'),
     'senior-editors': ('senior-editors', 'senior-editor'),
     'author-funding': ('author-funding', 'author-funding'),
     'themes': ('themes', 'theme'),
@@ -578,14 +577,32 @@ class TestParseXml:
                 'received_timestamp': TIMESTAMP_1
             }]]
 
-        def test_should_extract_single_reviewing_editor(self):
+        def test_should_extract_single_reviewing_editor_from_editors_element(self):
             result = _parse_xml_with_defaults(
                 _manuscript_xml([_version_node({
                     **VERSION_1,
-                    'reviewing-editors': [{
+                    'editors/editor': [{
                         'editor-person-id': PERSON_ID_1,
                         'editor-assigned-date': NON_ISO_TIMESTAMP_1,
                         'editor-decision-due-date': NON_ISO_TIMESTAMP_1,
+                    }]
+                })])
+            )
+            assert _versions_prop(result.versions, 'reviewing_editors') == [[{
+                'person_id': PERSON_ID_1,
+                'assigned_timestamp': TIMESTAMP_1,
+                'due_timestamp': TIMESTAMP_1
+            }]]
+
+        def test_should_extract_single_reviewing_editor_from_reviewing_editors_element(
+                self):
+            result = _parse_xml_with_defaults(
+                _manuscript_xml([_version_node({
+                    **VERSION_1,
+                    'reviewing-editors/reviewing-editor': [{
+                        'reviewing-editor-person-id': PERSON_ID_1,
+                        'reviewing-editor-assigned-date': NON_ISO_TIMESTAMP_1,
+                        'reviewing-editor-decision-due-date': NON_ISO_TIMESTAMP_1,
                     }]
                 })])
             )


### PR DESCRIPTION
part of https://github.com/elifesciences/issues/issues/4983

This will extract suggested reviewing and senior editors which were previously not extracted (or present in the XML).

eJP will also change XML elements. This keeps support for old and new names so that we should be able to deploy it before eJP apply the change to production (currently scheduled for 27 May).

eJP's test site has already the new change in and there is one dump (`ejp_elifetest_2020_05_22_14_00_00_2020_05_22_14_59_59.zip`) having the changes in.