### PR TITLE
don't remove false value json

### DIFF
--- a/ejp_xml_pipeline/transform_json.py
+++ b/ejp_xml_pipeline/transform_json.py
@@ -2,7 +2,7 @@ def remove_key_with_null_value(record):
     if isinstance(record, dict):
         for key in list(record):
             val = record.get(key)
-            if not val:
+            if not val and not isinstance(val, bool):
                 record.pop(key, None)
             elif isinstance(val, (dict, list)):
                 remove_key_with_null_value(val)

--- a/tests/unit_test/transform_json_test.py
+++ b/tests/unit_test/transform_json_test.py
@@ -1,0 +1,21 @@
+from ejp_xml_pipeline.transform_json import remove_key_with_null_value
+
+
+class TestRemoveKeyWithNullValue:
+    def test_should_remove_none_from_dict(self):
+        assert remove_key_with_null_value({
+            'key1': None,
+            'other': 'value'
+        }) == {'other': 'value'}
+
+    def test_should_remove_empty_string_from_dict(self):
+        assert remove_key_with_null_value({
+            'key1': '',
+            'other': 'value'
+        }) == {'other': 'value'}
+
+    def test_should_remove_not_remove_false_from_dict(self):
+        assert remove_key_with_null_value({
+            'key1': False,
+            'other': 'value'
+        }) == {'key1': False, 'other': 'value'}


### PR DESCRIPTION
It currently treats `False` as null.
That has the effect that boolean values are either `true` or `null` which seems wrong.
Another issue is that, if we didn't encounter a `true` value yet, then the schema won't include the field.

e.g. `manuscript_version_all.potential_senior_editors.suggested_to_exclude` was not added.