### PR TITLE
downgraded cattrs to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ python-dateutil==2.8.1
 pytz==2020.1
 boto3==1.16.6
 bigquery-schema-generator==1.2
+cattrs==1.0.0
 cloudpickle==1.4.1
 apache-airflow[crypto,celery,postgres,jdbc,ssh]==1.10.12
 dask[complete]==2.30.0


### PR DESCRIPTION
see https://github.com/elifesciences/data-hub-core-airflow-dags/pull/238

this has now caused other PRs to fail